### PR TITLE
Reset console colours after displaying branch list

### DIFF
--- a/Githelper/Helpers/Git/GitActions.cs
+++ b/Githelper/Helpers/Git/GitActions.cs
@@ -18,7 +18,6 @@ namespace Githelper.Helpers.Git
                     Console.BackgroundColor = ConsoleColor.White;
                     Console.ForegroundColor = ConsoleColor.Black;
                     Console.WriteLine($"{i + 1}: {Branches[i]}");
-                    Console.ResetColor();
                 }
                 else
                 {
@@ -27,6 +26,7 @@ namespace Githelper.Helpers.Git
                     Console.WriteLine($"{i + 1}: {Branches[i]}");
                 }
             }
+            Console.ResetColor();
 
             int.TryParse(Console.ReadLine(), out int Input);
 


### PR DESCRIPTION
Previously was resetting colours every second interation of the loop, moved the reset to the end of the loop to ensure it always resets